### PR TITLE
Update routing.js

### DIFF
--- a/packages/expo-router/build/global-state/routing.js
+++ b/packages/expo-router/build/global-state/routing.js
@@ -139,7 +139,8 @@ function getNavigateAction(state, parentState, type = 'NAVIGATE') {
     const currentRoute = parentState.routes.find((parentRoute) => parentRoute.name === route.name);
     const routesAreEqual = parentState.routes[parentState.index] === currentRoute;
     // If there is nested state and the routes are equal, we should keep going down the tree
-    if (route.state && routesAreEqual && currentRoute.state) {
+    // unless the type is push, in which case we should just push the state
+    if (route.state && routesAreEqual && currentRoute.state && type !== 'PUSH') {
         return getNavigateAction(route.state, currentRoute.state, type);
     }
     // Either we reached the bottom of the state or the point where the routes diverged


### PR DESCRIPTION
# Why

Was still having issues with pushing even after v3 latest changes, where router.push() was still performing as router.pushOrPop(). 

# How

When users directly use router.push() the route should be pushed - it shouldn't go back down through all the states and pop the last state, it should just push to the stack. 

# Test Plan

Verify when router.push() is used, that the new route is always pushed to the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
